### PR TITLE
Use bash as default interpreter and updates to kill scripts.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Black        0;30     Dark Gray     1;30
 # Red          0;31     Light Red     1;31

--- a/install/install_docker.sh
+++ b/install/install_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . ../common.sh
 
 eval 'docker --version' > /dev/null 2>&1

--- a/install/install_maven.sh
+++ b/install/install_maven.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . ../common.sh
 
 java -version > /dev/null 2>&1

--- a/install/install_nodejs.sh
+++ b/install/install_nodejs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ $EUID -ne 0 ]]; then
   display_error "This script must be run as root"

--- a/install/install_openJdk8.sh
+++ b/install/install_openJdk8.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . ../common.sh
 
 if [[ $EUID -ne 0 ]]; then

--- a/install/install_oracleJdk8.sh
+++ b/install/install_oracleJdk8.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . ../common.sh
 
 jdk_version='jdk-8u161'

--- a/install/install_oracleJdk9.sh
+++ b/install/install_oracleJdk9.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . ../common.sh
 
 BASE_URL_9=http://download.oracle.com/otn-pub/java/jdk/9.0.1+11/jdk-9.0.1_

--- a/kafka-src/git_clone_kafka.sh
+++ b/kafka-src/git_clone_kafka.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 kafka_git_url="https://github.com/apache/kafka.git"
 target_dir="kafka.git"

--- a/kafka-src/install_gradle.sh
+++ b/kafka-src/install_gradle.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 parent_dir="$(dirname "$(pwd)")"
 gradle_version='4.0.1'

--- a/kafka-src/install_maven.sh
+++ b/kafka-src/install_maven.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 parent_dir="$(dirname "$(pwd)")"
 gradle_version='4.0.1'

--- a/kafka-src/mvn_install_kafka_jars.sh
+++ b/kafka-src/mvn_install_kafka_jars.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 groupid='kafka'
 version='1.0.0-SNAPSHOT'

--- a/kafka-src/tar_kafka_jars.sh
+++ b/kafka-src/tar_kafka_jars.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 mkdir kafka-sources
 mkdir kafka-binaries

--- a/kafka/add_firewall_port_forwarding_rules.sh
+++ b/kafka/add_firewall_port_forwarding_rules.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0) 
 . ../common.sh
 

--- a/kafka/all_in_one_standup.sh
+++ b/kafka/all_in_one_standup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 
 ./start_kafka_zookeeper.sh

--- a/kafka/all_in_one_tear_down.sh
+++ b/kafka/all_in_one_tear_down.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 
 ./kill_kafka_broker.sh

--- a/kafka/build_kafka_configuration.sh
+++ b/kafka/build_kafka_configuration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . /kafka_common.sh
 
 if [ -z $KAFKA_HOME ]; then

--- a/kafka/capture_current_kafka_state.sh
+++ b/kafka/capture_current_kafka_state.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/check_consumer_group_offset.sh
+++ b/kafka/check_consumer_group_offset.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/check_status.sh
+++ b/kafka/check_status.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0) 
 . ./kafka_common.sh
 

--- a/kafka/cleanup_kafka_runtime.sh
+++ b/kafka/cleanup_kafka_runtime.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/create_topic.sh
+++ b/kafka/create_topic.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/display_kafka_configs.sh
+++ b/kafka/display_kafka_configs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/firewall_cmds.sh
+++ b/kafka/firewall_cmds.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0) 
 . ../common.sh
 

--- a/kafka/kafka_common.sh
+++ b/kafka/kafka_common.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . ../common.sh
 
 host_name=`hostname| cut -d"." -f1`

--- a/kafka/kafka_config_diff.sh
+++ b/kafka/kafka_config_diff.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . ../common.sh
 
 v1='0.10.1.1'

--- a/kafka/kill_kafka_broker.sh
+++ b/kafka/kill_kafka_broker.sh
@@ -5,13 +5,16 @@ cd $(dirname $0)
 PIDS=$(ps ax | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}')
 
 if [ -z "$PIDS" ]; then
-  display_error "No kafka broker process(es) found to stop"
+  display_error "No kafka broker process(es) found to stop."
   exit 0
 else
   for each in $PIDS; do
-    msg="about to kill process(es): $each"
-    display_warn $msg
+    display_warn "about to terminate process ${each}..."
     sleep 1
-    kill -9 $each
+    if kill -TERM $each ; then
+	display_info "Terminated process ${each}."
+    else
+	display_error "Failed to terminate process ${each}!"
+    fi
   done
 fi

--- a/kafka/kill_kafka_broker.sh
+++ b/kafka/kill_kafka_broker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0) 
 . ../common.sh
 

--- a/kafka/kill_kafka_mirror_maker.sh
+++ b/kafka/kill_kafka_mirror_maker.sh
@@ -5,13 +5,16 @@ cd $(dirname $0)
 PIDS=$(ps ax | grep java | grep -i MirrorMaker | grep -v grep | awk '{print $1}')
 
 if [ -z "$PIDS" ]; then
-  display_error "No kafka mirror-maker process(es) found to stop"
+  display_error "No Kafka Mirror Maker process(es) found to stop."
   exit 0
 else
   for each in $PIDS; do
-    msg="about to kill process(es): $each"
-    display_warn $msg
+    display_warn "about to terminate process ${each}..."
     sleep 1
-    kill -9 TERM $each
+    if kill -TERM $each ; then
+        display_info "Terminated process ${each}."
+    else
+        display_error "Failed to terminate process ${each}!"
+    fi
   done
 fi

--- a/kafka/kill_kafka_mirror_maker.sh
+++ b/kafka/kill_kafka_mirror_maker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0) 
 . ../common.sh
 

--- a/kafka/kill_kafka_zookeeper.sh
+++ b/kafka/kill_kafka_zookeeper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ../common.sh
 

--- a/kafka/kill_kafka_zookeeper.sh
+++ b/kafka/kill_kafka_zookeeper.sh
@@ -9,9 +9,12 @@ if [ -z "$ZK_PIDS" ]; then
   exit 0
 else
   for each in $ZK_PIDS; do
-    msg="about to kill process(es): $each"
-    echo -e $msg
+    display_warn "about to terminate process ${each}..."
     sleep 1
-    kill -9 $each
+    if kill -TERM $each ; then
+	display_info "Terminated process ${each}."
+    else
+	display_error "Failed to terminate process ${each}!"
+    fi
   done
 fi

--- a/kafka/list_active_consumer_groups.sh
+++ b/kafka/list_active_consumer_groups.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0) 
 . ./kafka_common.sh
 

--- a/kafka/list_partions_on_topic.sh
+++ b/kafka/list_partions_on_topic.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/list_topics.sh
+++ b/kafka/list_topics.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/modify_partitions_on_topic.sh
+++ b/kafka/modify_partitions_on_topic.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/run_tcpdump.sh
+++ b/kafka/run_tcpdump.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 display_interfaces=`ifconfig |grep '^[a-z]'|awk '{print $1}'| sed 's/.$//'| tr '\n' '  '`
 echo "Network interfaces: $display_interfaces"

--- a/kafka/start_kafka_broker.sh
+++ b/kafka/start_kafka_broker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/start_kafka_console_consumer.sh
+++ b/kafka/start_kafka_console_consumer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/start_kafka_console_producer.sh
+++ b/kafka/start_kafka_console_producer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/start_kafka_console_producer_from_file.sh
+++ b/kafka/start_kafka_console_producer_from_file.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/start_kafka_mirror_maker.sh
+++ b/kafka/start_kafka_mirror_maker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/start_kafka_zookeeper.sh
+++ b/kafka/start_kafka_zookeeper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/tail_kafka_broker_console_log.sh
+++ b/kafka/tail_kafka_broker_console_log.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/tail_kafka_controller_log.sh
+++ b/kafka/tail_kafka_controller_log.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/tail_kafka_mirror_maker_console_log.sh
+++ b/kafka/tail_kafka_mirror_maker_console_log.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/tail_kafka_zookeeper_console_log.sh
+++ b/kafka/tail_kafka_zookeeper_console_log.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/test_kafka_broker_running.sh
+++ b/kafka/test_kafka_broker_running.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/test_kafka_mirror_maker_running.sh
+++ b/kafka/test_kafka_mirror_maker_running.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/kafka/test_kafka_zookeeper_running.sh
+++ b/kafka/test_kafka_zookeeper_running.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $(dirname $0)
 . ./kafka_common.sh
 

--- a/mirror-maker-docker/docker_build_kafka_image.sh
+++ b/mirror-maker-docker/docker_build_kafka_image.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . ../kafka/kafka_common.sh
 set_kafka_variables

--- a/mirror-maker-docker/docker_compose_run_mirror_maker_service.sh
+++ b/mirror-maker-docker/docker_compose_run_mirror_maker_service.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f kafka/config/mm_consumer.properties ]; then
   display_error "No mirror-maker configuration found. Run docker_build_kafka_image first."

--- a/mirror-maker-docker/docker_compose_scale_mirror_maker_service.sh
+++ b/mirror-maker-docker/docker_compose_scale_mirror_maker_service.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 scale=`docker-compose ps|  sed 1,2d| grep kafka-mirror-maker-service| wc -l`
 service="kafka-mirror-maker-service"

--- a/mirror-maker-docker/docker_compose_teardown.sh
+++ b/mirror-maker-docker/docker_compose_teardown.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 docker-compose stop
 docker-compose rm

--- a/mirror-maker-docker/docker_run_temporary_container.sh
+++ b/mirror-maker-docker/docker_run_temporary_container.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
 docker run -ti --rm mycompany/kafka /bin/bash 

--- a/utils/ConsoleConsumerStatsViewer/generate_raw_dataset.sh
+++ b/utils/ConsoleConsumerStatsViewer/generate_raw_dataset.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . ../../common.sh
 
 for var in "$@"

--- a/utils/HttpKafkaAdapter/generate_http_traffic.sh
+++ b/utils/HttpKafkaAdapter/generate_http_traffic.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . ../../common.sh
 
 data=$data_dir/MOCK_DATA.json

--- a/utils/HttpKafkaAdapter/start_demo.sh
+++ b/utils/HttpKafkaAdapter/start_demo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . ../../common.sh
 

--- a/utils/HttpKafkaAdapter/start_springboot.sh
+++ b/utils/HttpKafkaAdapter/start_springboot.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 broker_host_port='localhost:9091'

--- a/utils/KafkaVolumetrics/build_it.sh
+++ b/utils/KafkaVolumetrics/build_it.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
 mvn clean install

--- a/utils/KafkaVolumetrics/run_it.sh
+++ b/utils/KafkaVolumetrics/run_it.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 BOLD="\033[1m"
 YELLOW="\033[38;5;11m"


### PR DESCRIPTION
Replace /bin/sh with /bin/bash as the interpreter. This ensures we get bash to run our scripts instead of whatever is linked to /bin/sh (i.e. /bin/dash on Ubuntu). Fixed a bug in kill_kafka_mirror_maker.sh script that caused a spurious error message to be generated. Use SIGTERM instead of SIGKILL to shut down processes to give processes a chance to clean up. Add feedback to tell if the kill was successful or not.